### PR TITLE
clean: Markdown headings separate from paragraphs

### DIFF
--- a/confidence_intervals.ipynb
+++ b/confidence_intervals.ipynb
@@ -11,8 +11,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Agenda\n",
-    "\n",
+    "## Agenda"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "SWBAT:\n",
     "\n",
     "- Describe the use of confidence intervals;\n",
@@ -40,8 +45,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## $z$-Tables\n",
-    "\n",
+    "## $z$-Tables"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Let's start with the notion of a [$z$-table](http://z-table.com)."
    ]
   },
@@ -49,8 +59,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Intuition\n",
-    "\n",
+    "## Intuition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Because sample statistics are imperfect representations of the true population values, it is often appropriate to state these estimates with **confidence intervals**.\n",
     "\n",
     "Suppose I weigh a sample of 50 jellybeans from a population of 10000 and find the average weight to be 1.25 grams. Can I take this figure to be a good estimate of the average weight over the whole *population* of jelly beans?\n",
@@ -69,8 +84,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Interpretation\n",
-    "\n",
+    "## Interpretation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Here's another example: Suppose our Indian correspondent (or David Attenborough) takes several hundred measurements of parrot beak lengths in the Ganges river basin and calculates (correctly!) an average beak length of 9cm. He reports this measure by saying that the 90%-confidence interval is (8.6, 9.4).\n",
     "\n",
     "This does NOT mean that the true population mean beak length has a 90% chance of being somewhere between 8.6cm and 9.4cm. After all, the true mean either falls in that range or it doesn't. The notion of probability *here* doesn't seem to make much sense. Rather, what our correspondent means is that, if we were to conduct the same measuring experiment many times, constructing intervals in the same way, we should expect 90% of those intervals to contain the true population mean."
@@ -80,8 +100,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Construction\n",
-    "\n",
+    "## Construction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "OK: So how do we construct these intervals?\n",
     "\n",
     "The confidence interval we construct will depend on the statistics of our sample. It will depend in particular on (i) our sample mean and (ii) our sample size.\n",
@@ -97,8 +122,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## CIs for Normally Distributed Data\n",
-    "\n",
+    "## CIs for Normally Distributed Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Let's look at an example with data we assume to be normally distributed:"
    ]
   },
@@ -187,14 +217,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## CIs for Non-Normally Distributed Data\n",
-    "\n",
+    "## CIs for Non-Normally Distributed Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "One of the most commonly used strategies for dealing with non-normally distributed data is to find a way to reduce the problem to one that involves normally distributed data!\n",
     "\n",
-    "[Here](https://file.scirp.org/Html/3-1240887_76758.htm) is a review article that compares several different strategies. (Note that it ultimately recommends a sort of Bayesian method. We'll get to Bayesian reasoning in a later lesson.)\n",
-    "\n",
-    "## $t$-Distribution\n",
-    "\n",
+    "[Here](https://file.scirp.org/Html/3-1240887_76758.htm) is a review article that compares several different strategies. (Note that it ultimately recommends a sort of Bayesian method. We'll get to Bayesian reasoning in a later lesson.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## $t$-Distribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "![imgguiness](./img/guiness.png)\n",
     "\n",
     "We can use the normal distribution when either:\n",
@@ -236,15 +281,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## CIs for $t$-Distribution\n",
-    "\n",
+    "## CIs for $t$-Distribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The construction of confidence intervals for the t-Distribution is similar to how they are made for the normal distribution. But instead of z-scores, we'll have t-scores. And since we don't have access to the population standard deviation, we'll make use of the sample standard deviation instead.\n",
     "\n",
     "left endpt.: $\\bar{x} - t\\times\\frac{s}{\\sqrt{n}}$ <br/>\n",
-    "right endpt.: $\\bar{x} + t\\times\\frac{s}{\\sqrt{n}}$\n",
-    "\n",
-    "### $t$-Distribution Example\n",
-    "\n",
+    "right endpt.: $\\bar{x} + t\\times\\frac{s}{\\sqrt{n}}$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### $t$-Distribution Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "You are inspecting a hardware factory and want to construct a 90% confidence interval of acceptable screw lengths. You draw a sample of 30 screws and calculate their mean length as 4.8 centimeters and the standard deviation as 0.4 centimeters. What are the bounds of your confidence interval?"
    ]
   },
@@ -286,8 +346,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Binomial Distribution\n",
-    "\n",
+    "## Binomial Distribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "What if we have a binomial distribution? Suppose we have the following sample statistic:\n",
     "\n",
     "A survey of 3000 voters found that 1245 approved of the job the governor was doing. How can we express our 95%-confidence level about voter approval of the governor among _all_ voters?\n",
@@ -329,12 +394,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## CIs for Other Parameters\n",
-    "\n",
-    "We might be interested in constructing confidence intervals for other parameters, such as the variance. [This online course](https://newonlinecourses.science.psu.edu/stat414/) has several good examples.\n",
-    "\n",
-    "## A Visual Interpretation of Confidence Intervals\n",
-    "\n",
+    "## CIs for Other Parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We might be interested in constructing confidence intervals for other parameters, such as the variance. [This online course](https://newonlinecourses.science.psu.edu/stat414/) has several good examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A Visual Interpretation of Confidence Intervals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Let's see if we can get an idea of how confidence intervals work by constructing a plot:"
    ]
   },
@@ -394,7 +474,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Separating the headings from the paragraphs allow better use of
  Markdown section folding (Collapsible Headings extension.

Address enhancement #1 