### PR TITLE
stats.t.interval formula, copy edits

### DIFF
--- a/confidence_intervals.ipynb
+++ b/confidence_intervals.ipynb
@@ -475,6 +475,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "# Take a sample from the population\n",
+    "np.random.seed(42)\n",
+    "sample = np.random.choice(a=population, size=50)\n",
+    "\n",
+    "# Find the sample mean\n",
+    "sample_mean = np.mean(sample)\n",
+    "sample_mean"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "hidden": true
@@ -507,22 +524,29 @@
    },
    "outputs": [],
    "source": [
-    "np.random.seed(42)\n",
-    "sample = np.random.choice(a=population, size=50)\n",
-    "np.mean(sample)"
+    "# Finding standard error\n",
+    "standard_error = pop_std / np.sqrt(50)\n",
+    "standard_error"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once we have the mean, z, and standard error, we can calculate the CI:\n",
+    "\n",
+    "left endpt.: $\\bar{x} - z\\times\\frac{\\sigma}{\\sqrt{n}}$ <br/>\n",
+    "right endpt.: $\\bar{x} + z\\times\\frac{\\sigma}{\\sqrt{n}}$"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# Converting our z-score to \n",
-    "standard_error = pop_std / np.sqrt(50)\n",
-    "standard_error * z"
+    "# Finding confidence interval\n",
+    "(sample_mean - z * standard_error, sample_mean + z * standard_error)"
    ]
   },
   {
@@ -657,29 +681,58 @@
     "hidden": true
    },
    "source": [
-    "The construction of confidence intervals for the $t$-distribution is similar to how they are made for the normal distribution. But instead of $z$-scores, we'll have $t$-scores. And since we don't have access to the population standard deviation, we'll make use of the sample standard deviation instead.\n",
+    "The construction of confidence intervals for the $t$-distribution is similar to how they are made for the normal distribution. But instead of $z$-scores, we'll have $t$-scores. And if we don't have access to the population standard deviation, we'll make use of the sample standard deviation instead.\n",
     "\n",
     "left endpt.: $\\bar{x} - t\\times\\frac{s}{\\sqrt{n}}$ <br/>\n",
-    "right endpt.: $\\bar{x} + t\\times\\frac{s}{\\sqrt{n}}$"
+    "right endpt.: $\\bar{x} + t\\times\\frac{s}{\\sqrt{n}}$\n",
+    "\n",
+    "Let's use the same example from above, this time creating a 90% CI using the t-distribution."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "conf_int = 0.95\n",
+    "# Find the t-score, specifying degrees of freedom\n",
+    "t = stats.t.ppf(0.95, df=50-1)\n",
+    "t"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate the confidence interval\n",
+    "(sample_mean - t * standard_error, sample_mean + t * standard_error)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that because we have 50 items in our sample, this answer is not very different using the t-distribution compared to the normal distribution.\n",
     "\n",
-    "interval_start, interval_end = stats.t.interval(\n",
-    "                 alpha = conf_int,  # Confidence level\n",
-    "                 df = 99,           # Degrees of freedom\n",
-    "                 loc = 65,          # Sample mean\n",
-    "                 scale = 18)        # Standard deviation estimate\n",
+    "#### `stats.t.interval` Interface\n",
     "\n",
-    "print(f'To get {conf_int*100}%: {interval_start} to {interval_end}')"
+    "There is also an alternative interface for calculating the confidence interval if we don't need to access the t-statistic directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stats.t.interval(\n",
+    "    alpha=0.9,           # Confidence level\n",
+    "    df=50-1,             # Degrees of freedom\n",
+    "    loc=sample_mean,     # Sample mean\n",
+    "    scale=standard_error # Unit scale for t-distribution\n",
+    ")"
    ]
   },
   {
@@ -741,7 +794,7 @@
    },
    "outputs": [],
    "source": [
-    "#Min and Max of Confidence Interval\n",
+    "# Min and Max of Confidence Interval\n",
     "stats.t.interval(alpha = 0.95,          \n",
     "                 df = len(samples)-1,    \n",
     "                 loc = samples.mean(),\n",
@@ -814,7 +867,16 @@
     "> There is a 95% probability that the mean age is between 26.3 and 28.3\n",
     "\n",
     "Correct:\n",
-    "> If we find 100 (random) samples and create confidence intervals, we expect 95 intervals would contain the true mean of population age.\n"
+    "> If we find 100 (random) samples and create confidence intervals, we expect 95 intervals would contain the true mean of population age.\n",
+    "\n",
+    "> We are confident in this interval because we expect that a true population mean outside of this interval would produce these results 5% or less of the time. In other words, only an unlikely (but not impossible) sampling event could have caused us to calculate this interval, if the true mean is outside of this interval.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**The true population mean is a specific value and we do not know what it is.** The confidence level you choose is a question of how often you are willing to find an interval that does not include the true population mean, but it doesn't tell you whether this particular sample + interval calculation gave you the \"right\" answer."
    ]
   },
   {


### PR DESCRIPTION
The most important change was to modify the `stats.t.interval` invocation that said "Standard deviation estimate" so that it would say "Unit scale for t-distribution" instead.

("Standard deviation estimate" is maybe technically not-wrong, but led to confusion when students were interested in seeing the `stats.t.interval` approach side-by-side with the `stats.t.ppf` approach, and I plugged in the sample standard deviation rather than the sample standard error of the mean.)

Other changes are more cosmetic:

- z-score CI
  - Moved the code that took the sample and found the mean above the code that found the z-score
  - Added a markdown cell introducing the CI formula
  - Added a code cell that displayed the CI instead of just displaying the margin of error
- t-score CI
  - Changed the first example so that it uses the same numbers as the z-score example, and uses `stats.t.ppf`, to highlight the similarities and differences (previous version had different numbers, and used `stats.t.interval`)
  - Then used those same numbers in the `stats.t.interval` example, with appropriate comments
- CI interpretation
  - Added slightly more text describing what we can and can't say about the result of a CI calculation